### PR TITLE
两个连接使用interceptor的bug

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -22,6 +22,7 @@ var Interceptor = function(target) {
   this.inStream = net.createServer(this._connectionHandler.bind(this));
   this.blocking = false;
   this.closed = false;
+  this.outArr = [];
 }
 
 /**
@@ -39,24 +40,25 @@ Interceptor.prototype.listen = function() {
  * @private
  */
 Interceptor.prototype._connectionHandler = function(socket) {
-  this.outStream = net.connect(this.target[1], this.target[0]);
-  this.outStream.on('data', function(data) {
+  var outStream = net.connect(this.target[1], this.target[0]);
+  this.outArr.push(outStream);
+  outStream.on('data', function(data) {
     !this.blocking && socket.write(data);
   }.bind(this));
 
-  this.outStream.on('end', function(data) {
+  outStream.on('end', function(data) {
     !this.blocking && socket.end(data);
   }.bind(this));
 
-  this.outStream.on('error', function(err) {
+  outStream.on('error', function(err) {
     !this.blocking && socket.emit('error', err);
   }.bind(this));
   socket.on('data', function(data) {
-    !this.blocking && this.outStream.write(data);
+    !this.blocking && outStream.write(data);
   }.bind(this));
 
   socket.on('end', function(data) {
-    this.outStream.end(data);
+    outStream.end(data);
     if (this.blocking && !this.closed) {
       this.inStream.close();
       this.closed = true;
@@ -64,7 +66,7 @@ Interceptor.prototype._connectionHandler = function(socket) {
   }.bind(this));
 
   socket.on('error', function(err) {
-    !this.blocking && this.outStream.emit('error', err);
+    !this.blocking && outStream.emit('error', err);
   }.bind(this));
 }
 
@@ -87,7 +89,9 @@ Interceptor.prototype.open = function() {
 }
 
 Interceptor.prototype.close = function() {
-  this.outStream && this.outStream.end();
+  this.outArr.forEach(function (c) {
+    c.end();
+  });
   if (!this.closed) {
     this.inStream && this.inStream.close();
     this.closed = true;

--- a/test/interceptor.test.js
+++ b/test/interceptor.test.js
@@ -34,6 +34,32 @@ describe('#interceptor', function() {
       client.write('ping');
     });
 
+    it('should ok connect twice', function(done) {
+      var count = 2;
+      var client2 = net.connect(16788, '127.0.0.1');
+      client2.once('data', function(data) {
+        String(data).should.equal('ping');
+        if (--count === 0){
+          client2.end();
+          setTimeout(function () {
+            done();
+          }, 100);
+        }
+      });
+      client2.write('ping');
+
+      client.once('data', function(data) {
+        String(data).should.equal('ping');
+        if (--count === 0){
+          client2.end();
+          setTimeout(function () {
+            done();
+          }, 100);
+        }
+      });
+      client.write('ping');
+    });
+
     it('should intercept by proxy', function(done) {
       proxy.block();
       var timer = setTimeout(function() {


### PR DESCRIPTION
如果两个连接连接interceptor，interceptor对后端服务器只有一个连接this.outStream。这导致了建立第二个连接的时候，覆盖了第一个连接，第一个连接就丢失了。如果每个连接都有自己维护的状态，那么第一个连接无疑就有问题了。已经fix
